### PR TITLE
Support symlinked folders for development

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,8 @@ const config = {
     locales: ['en'],
   },
   plugins: [
-    require.resolve('./plugins/homepage-items-plugin'),
+      require.resolve('./plugins/support-symlinks'),
+      require.resolve('./plugins/homepage-items-plugin'),
   ],
 
   presets: [

--- a/plugins/homepage-items-plugin.js
+++ b/plugins/homepage-items-plugin.js
@@ -14,8 +14,9 @@ module.exports = function (context, options) {
             const sidebarDirs = Object.values(sidebars).map(sidebar => sidebar[0].dirName);
             const packages = sidebarDirs.map((dir) => {
                 const folder = path.join(docsDirectory, dir)
-                if (fs.statSync(folder).isDirectory() && fs.statSync(path.join(folder, "_category_.json")).isFile()) {
-                    const category = require(path.join(folder, "_category_.json"));
+                const realPath = fs.lstatSync(folder).isSymbolicLink() ? fs.realpathSync(folder) : folder;
+                if (fs.statSync(realPath).isDirectory() && fs.statSync(path.join(realPath, "_category_.json")).isFile()) {
+                    const category = require(path.join(realPath, "_category_.json"));
                     return {
                         label: category.label,
                         description: category.customProps.description,

--- a/plugins/support-symlinks.js
+++ b/plugins/support-symlinks.js
@@ -1,0 +1,14 @@
+module.exports = function (context, options) {
+    return {
+        name: 'support-symlinks',
+        configureWebpack(config, isServer, utils) {
+
+            return {
+                resolve: {
+                    ...config.resolve,
+                    symlinks: false,
+                }
+            }
+        },
+    };
+};

--- a/sidebars.js
+++ b/sidebars.js
@@ -9,7 +9,7 @@ const sidebars = {};
 
 function fileExists(path) {
     try {
-        return fs.statSync(path).isFile();
+        return fs.lstatSync(path).isFile();
     } catch {
         return false;
     }
@@ -17,9 +17,11 @@ function fileExists(path) {
 
 projects.forEach((project) => {
     const docsDir = path.join(docsDirectory, project);
-    if (fs.statSync(docsDir).isDirectory()) {
-        const categoryFile = path.join(docsDir, "_category_.json");
-        if(fileExists(categoryFile)) {
+    const realPath = fs.lstatSync(docsDir).isSymbolicLink() ? fs.realpathSync(docsDir) : docsDir;
+
+    if (fs.statSync(realPath).isDirectory()) {
+        const categoryFile = path.join(realPath, "_category_.json");
+        if (fileExists(categoryFile)) {
             const category = require(categoryFile);
             sidebars[category.label] = [category.customProps.sidebar];
         } else {


### PR DESCRIPTION
These changes allow devs to symlink their docs folder into the ir-docs repo to locally preview the changes they are making before commiting.