### PR TITLE
Set up Algolia search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -176,6 +176,26 @@ const config:Config = {
           },
         ],
       },
+    algolia: {
+      // The application ID provided by Algolia
+      appId: "PF58ZGOE1X",
+
+      // Public API key: it is safe to commit it
+      apiKey: "124e3bdd34363402f406c662f8a542d3",
+
+      indexName: "infinite",
+
+      // Optional: see doc section below
+      contextualSearch: true,
+
+      // Optional: Algolia search parameters
+      searchParameters: {},
+
+      // Optional: path for search page that enabled by default (`false` to disable it)
+      searchPagePath: "search",
+
+      //... other Algolia params
+    },
     }) satisfies Preset.ThemeConfig,
 };
 


### PR DESCRIPTION
Sets up basic search for IR docs using Algolia.

This should be able to find everything on the site: let me know if there's something you search for that it can't find, or if you get irrelevant search results for your queries.

<img width="767" alt="Screenshot 2024-06-06 at 4 21 39 PM" src="https://github.com/infinitered/ir-docs/assets/5252268/8199c0ba-14c7-4885-be1a-e16c545099ae">

## Testing

Just pull this branch, install deps and run `yarn start`. It should Just Work (TM).

## Future improvements

There are improvements I'd like to make in the future to make this easier to use, primarily revolving around the fact that this site covers documentation for several different tools

1. Standardize naming and casing ("Ignite-cli" in the top bar should probably just be "Ignite", especially since there's a "CLI" subheading, consistent capitalization on "React-native-mlkit", etc)
2. Segment results in the search modal by top-level product name (show "Ignite", not "Boilerplate" for results from the boilerplate docs) OR display breadcrumbs for each segment that show the entire header hierarchy. Otherwise it's hard to tell which product results are for.
3. Get Algolia to prioritize search results for the product docs you are currently viewing. I'm pretty sure this is possible with Algolia's facet filter feature (if what we need isn't already indexed, we can add custom values to facet by: https://docsearch.algolia.com/docs/record-extractor#indexing-content-for-faceting).